### PR TITLE
[Refactor] #10 - 사이드바 메뉴 선택 시 선택한 게 확인되도록 시각적 처리

### DIFF
--- a/Front/App.js
+++ b/Front/App.js
@@ -5,27 +5,45 @@ import LoginPage from './src/pages/Auth/LoginPage';
 import MainDrawerNavigator from './src/navigations/MainDrawerNavigator';
 import DashBoardModal from './src/components/DashBoardModal';
 import MapScreen from './src/pages/MapScreen';
+import { RouterProvider, useRouter } from './src/components/RouterContext';
 
 const Stack = createNativeStackNavigator();
 
-export default function App() {
+// 중첩 네비게이터에서도 현재 라우트 추출하는 함수
+function getActiveRouteName(state) {
+  if (!state || !state.routes || state.index == null) return '';
+  const route = state.routes[state.index];
+  if (route.state) {
+    return getActiveRouteName(route.state);
+  }
+  return route.name;
+}
+
+const AppContent = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const { setCurrentRoute } = useRouter(); // 현재 라우트 이름을 저장하는 함수
 
   return (
-    <NavigationContainer>
+    <NavigationContainer
+      onStateChange={(state) => {
+        const route = getActiveRouteName(state);
+        setCurrentRoute(route);
+      }}
+    >
       <Stack.Navigator initialRouteName={isAuthenticated ? 'Main' : 'Login'} screenOptions={{ headerShown: false }}>
-        {/* 로그인 관련 화면 */}
         <Stack.Screen name="Login" component={LoginPage} />
-        
-        {/* 메인 애플리케이션 */}
         <Stack.Screen name="Main" component={MainDrawerNavigator} />
-
-          {/* OverlayPage for Modal*/}
-          <Stack.Screen name="DashBoardModal" component={DashBoardModal} />
-
+        <Stack.Screen name="DashBoardModal" component={DashBoardModal} />
         <Stack.Screen name="Map" component={MapScreen} />
-
       </Stack.Navigator>
     </NavigationContainer>
+  );
+};
+
+export default function App() {
+  return (
+    <RouterProvider>
+      <AppContent />
+    </RouterProvider>
   );
 }

--- a/Front/src/components/RouterContext.js
+++ b/Front/src/components/RouterContext.js
@@ -1,0 +1,16 @@
+// 현재 사용자가 보고 있는 페이지 경로(=route)를 전역에서 추적하기 위한 페이지
+import React, { createContext, useContext, useState } from 'react';
+
+const RouterContext = createContext();
+
+export const useRouter = () => useContext(RouterContext);
+
+export const RouterProvider = ({ children }) => {
+  const [currentRoute, setCurrentRoute] = useState('');
+
+  return (
+    <RouterContext.Provider value={{ currentRoute, setCurrentRoute }}>
+      {children}
+    </RouterContext.Provider>
+  );
+};

--- a/Front/src/components/Sidebar.js
+++ b/Front/src/components/Sidebar.js
@@ -2,67 +2,88 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import styles from '../styles/components/Sidebar.styles';
 import MainMenuData from '../datas/MainMenu';
+import { useRouter } from '../components/RouterContext';
 
-const Sidebar = ({navigation, isManager}) => {
-    const [expanded, setExpanded] = useState(null); // Track the expanded menu index
+const Sidebar = ({ navigation, isManager }) => {
+  const [expanded, setExpanded] = useState(null);
+  const { currentRoute } = useRouter();
 
-    const toggleExpand = (index) => {
-        setExpanded(expanded === index ? null : index);
-    };
+  const toggleExpand = (index) => {
+    setExpanded(expanded === index ? null : index);
+  };
 
-    const handleMenuClick = (menu, index) => {
-        if (menu.subItems) {
-            // 서브 아이템이 있다면 펼치거나 닫기
-            toggleExpand(index);
-        } else if (menu.routeName) {
-            // 서브 아이템이 없으면 바로 해당 페이지로 이동
-            navigation.navigate(menu.routeName);
-        }
-    };
-    const handleSubItemClick = (routeName) => {
-            navigation.navigate(routeName);
-        };
+  const handleMenuClick = (menu, index) => {
+    if (menu.subItems) {
+      toggleExpand(index);
+    } else if (menu.routeName) {
+      setExpanded(null);
+      navigation.navigate(menu.routeName);
+    }
+  };
 
+  const handleSubItemClick = (routeName) => {
+    navigation.navigate(routeName);
+  };
 
-    const filteredMenuData =
-        isManager ? MainMenuData
-        : MainMenuData.filter(menu => menu.title !== '검침원 관리');
+  const filteredMenuData = isManager
+    ? MainMenuData
+    : MainMenuData.filter(menu => menu.title !== '검침원 관리');
 
-    return (
-        <View style={styles.container}>
-            <View style={styles.sidebar}>
-                {filteredMenuData.map((menu, index) => (
-                    <View key={index}>
-                        {/* Main Menu Item */}
-                        <TouchableOpacity
-                            style={styles.menuItem}
-                            onPress={() => handleMenuClick(menu, index)}
-                        >
-                            <Text style={styles.menuText}>{menu.title}</Text>
-                            {menu.subItems && (
-                                <Text style={styles.arrow}>{expanded === index ? '▼' : '▶'}</Text>
-                            )}
-                        </TouchableOpacity>
+  const isMenuSelected = (menu) => {
+    if (!menu.subItems) return currentRoute === menu.routeName;
+    return menu.subItems.some(sub => sub.routeName === currentRoute);
+  };
 
-                        {/* Sub Menu Items */}
-                        {expanded === index && menu.subItems && (
-                            <View style={styles.subMenu}>
-                                {menu.subItems.map((subItem, subIndex) => (
-                                    <TouchableOpacity
-                                        key={subIndex}
-                                        style={styles.subItem}
-                                        onPress={() => handleSubItemClick(subItem.routeName)}
-                                    >
-                                        <Text style={styles.subText}>{subItem.title}</Text>
-                                    </TouchableOpacity>
-                                ))}
-                            </View>
-                        )}
-                    </View>
-                ))}
+  return (
+    <View style={styles.sidebar}>
+      {filteredMenuData.map((menu, index) => (
+        <View key={index}>
+          // 메인 메뉴
+        <TouchableOpacity
+          style={[
+            styles.menuItem,
+            isMenuSelected(menu) && styles.selectedMenuItem,
+          ]}
+          onPress={() => handleMenuClick(menu, index)}
+        >
+          <Text
+            style={[
+              styles.menuText,
+              isMenuSelected(menu) && styles.selectedMenuText,
+            ]}
+          >
+            {menu.title}
+          </Text>
+          {menu.subItems && (
+            <Text style={styles.arrow}>{expanded === index ? '▼' : '▶'}</Text>
+          )}
+        </TouchableOpacity>
+
+          // 서브 메뉴
+          {expanded === index && menu.subItems && (
+            <View style={styles.subMenu}>
+              {menu.subItems.map((subItem, subIndex) => (
+                <TouchableOpacity
+                  key={subIndex}
+                  style={styles.subItem}
+                  onPress={() => handleSubItemClick(subItem.routeName)}
+                >
+                  <Text
+                    style={[
+                      styles.subText,
+                      currentRoute === subItem.routeName && styles.selectedSubText,
+                    ]}
+                  >
+                    {subItem.title}
+                  </Text>
+                </TouchableOpacity>
+              ))}
             </View>
+          )}
         </View>
-    );
+      ))}
+    </View>
+  );
 };
 
 export default Sidebar;

--- a/Front/src/navigations/MainDrawerNavigator.js
+++ b/Front/src/navigations/MainDrawerNavigator.js
@@ -4,6 +4,7 @@ import DashBoardPage from '../pages/Monitoring/DashboardPage';
 import DashBoardPageNormal from '../pages/Monitoring/DashBoardPageNormal';
 import Sidebar from '../components/Sidebar';
 import Header from '../components/Header';
+import { useRouter } from '../components/RouterContext';
 import SOSCallPage from "../pages/Monitoring/SOSCallPage";
 import FallOccurrence from "../pages/Monitoring/FallOccurrence";
 import EnterDangerZone from "../pages/Monitoring/EnterDangerZone";
@@ -19,6 +20,7 @@ import WatchWearingStatusPage from "../pages/ElderlyManagement/WatchWearingStatu
 const Drawer = createDrawerNavigator();
 
 export default function MainDrawerNavigator() {
+  const { setCurrentRoute } = useRouter();
 
     const DUMMY_USER_INFO = {
         name: '한예원',

--- a/Front/src/styles/components/Sidebar.styles.js
+++ b/Front/src/styles/components/Sidebar.styles.js
@@ -1,47 +1,55 @@
 import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
-    sidebar: {
-        height: '100%',
-        backgroundColor: '#4369A3',
-        paddingVertical: 20,
+  sidebar: {
+    height: '100%',
+    backgroundColor: '#4369A3',
+    paddingVertical: 20,
+  },
+  menuItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 15,
+    paddingHorizontal: 15,
+    borderBottomWidth: 1,
+    borderBottomColor: '#3b5998',
+  },
+  menuText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+  },
+  arrow: {
+    color: '#FFFFFF',
+    fontSize: 18,
+  },
+  subMenu: {
+    backgroundColor: '#48648E',
+  },
+  subItem: {
+    paddingHorizontal: 15,
+    paddingVertical: 5,
+    justifyContent: 'center',
+  },
+  subText: {
+    fontSize: 12,
+    color: '#FFFFFF',
+  },
+
+  // 선택된 메인 메뉴
+  selectedMenuItem: {
+    backgroundColor: '#2B4367',
+    borderRadius: 4,
+  },
+    selectedMenuText: {
+      fontWeight: 'bold',
     },
-    sidebarHeader: {
-        color: '#fff',
-        fontSize: 18,
-        fontWeight: 'bold',
-        marginBottom: 20,
-        paddingHorizontal: 15,
-    },
-    menuItem: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        paddingVertical: 15,
-        paddingHorizontal: 15,
-        borderBottomWidth: 1,
-        borderBottomColor: '#3b5998',
-    },
-    menuText: {
-        color: '#FFFFFF',
-        fontSize: 16,
-    },
-    arrow: {
-        color: '#FFFFFF',
-        fontSize: 18,
-    },
-    subMenu: {
-        backgroundColor: '#48648E'
-    },
-    subItem: {
-        paddingHorizontal: 15,
-        paddingVertical: 5,
-        justifyContent: 'center',
-    },
-    subText: {
-        fontSize: 12,
-        color: '#FFFFFF',
-    },
+
+  // 선택된 서브 메뉴
+  selectedSubText: {
+    fontWeight: 'bold',
+    color: '#5CC1FF',
+  },
 });
 
 export default styles;


### PR DESCRIPTION
## Related Issue 🍀
- close #10 

<br>

## Key Changes 🔑
1. 하고 싶었던 것
    - 사이드바에서 선택된 메뉴의 스타일을 변경해, 강조된 상태로 보이게 하고 싶었음

2. 기존 코드
    - 현재 어떤 메뉴가 선택됐는지, 선택 시 애니메이션 외 알 수 있는 정보가 없었음
    - 여러 개의 메뉴가 동시에 열리는 경우 있음 (ex. 다른 메뉴 클릭 후 대시보드 눌러도 여전히 열려 있음)

3. 수정 사항
    - RouterContext 도입하여 현재 라우트 정보를 전역 상태로 관리하게 함
    - RouterProvider로 감싸고, useRouter()로 접근 가능하게 설정
    - NavigationContainer의 onStateChange에서 현재 라우트를 추적하여 setCurrentRoute로 업데이트함
    - Sidebar 컴포넌트에서 currentRoute 받아와서 스타일 조건부 적용
      - 선택된 메인 메뉴: fontWeight: bold, backgroundColor: #2B4367 적용
      - 선택된 서브 메뉴: fontWeight: bold, color: #5CC1FF 적용
    - 메인 메뉴 클릭 시 다른 메뉴 닫히도록 setExpanded(null) 적용

4. 변경된 UI
    - 선택된 메인 메뉴는 배경이 짙은 파란색으로 바뀜
    - 선택된 서브 메뉴는 텍스트 색이 밝은 파란색으로 강조됨
    - 현재 어떤 페이지에 있는지 직관적으로 파악 가능해짐

<br>

## Preview UI 📸 (선택)
<img width="184" alt="스크린샷 2025-04-06 02 39 21" src="https://github.com/user-attachments/assets/f22c6594-01dd-4173-8458-e05bf9e5b7f3" />

사진과 같이 선택된 메뉴에 강조 처리

<br>
